### PR TITLE
Expand metamask not found alert

### DIFF
--- a/app/(app)/(configure)/summary/page.tsx
+++ b/app/(app)/(configure)/summary/page.tsx
@@ -202,7 +202,7 @@ export default function Summary() {
                   }
                 });
             } else {
-              alert('Metamask not found');
+              alert('Metamask not found. Check if you have installed the Metamask browser extension. If you are on a mobile device, try switching to desktop.');
             }
           }}
         >


### PR DESCRIPTION
User was confused by "metamask not found" because they had the metamask app installed on mobile. Added more explanation to the alert to reduce confusion on this part of the flow.