### PR TITLE
fix(summary): add blockExplorerUrls to restore button functionality

### DIFF
--- a/app/(app)/(configure)/summary/page.tsx
+++ b/app/(app)/(configure)/summary/page.tsx
@@ -189,6 +189,7 @@ export default function Summary() {
                   decimals: 18,
                 },
                 rpcUrls: [constructRpcUrl().toString()],
+                blockExplorerUrls: ['https://etherscan.io'],
               };
               // do it manually with window.ethereum
               provider


### PR DESCRIPTION
The button was not working due to missing blockExplorerUrls. Adding this parameter resolves the issue and ensures the button functions correctly.