### PR TITLE
Ignore "h is not a function" error for rpc call

### DIFF
--- a/app/(app)/(configure)/summary/page.tsx
+++ b/app/(app)/(configure)/summary/page.tsx
@@ -205,7 +205,11 @@ export default function Summary() {
                 })
                 .catch((error: any) => {
                   // ignore 4001 "user rejected request" error code
-                  if (error.code !== 4001) {
+                  // ignore h is not a function error
+                  if (
+                    error.code !== 4001 &&
+                    error.message !== 'h is not a function'
+                  ) {
                     alert(`Error ${error.code}: ${error.message}`);
                   }
                 });

--- a/app/(app)/(configure)/summary/page.tsx
+++ b/app/(app)/(configure)/summary/page.tsx
@@ -205,11 +205,12 @@ export default function Summary() {
                 })
                 .catch((error: any) => {
                   // ignore 4001 "user rejected request" error code
-                  // ignore h is not a function error
-                  if (
-                    error.code !== 4001 &&
-                    error.message !== 'h is not a function'
-                  ) {
+                  if (error.code === 4001) {
+                    // do nothing
+                  } else if (error.message.includes('is not a function')) {
+                    // network was still added
+                    setAddedToMetamask(true);
+                  } else {
                     alert(`Error ${error.code}: ${error.message}`);
                   }
                 });

--- a/app/(app)/(configure)/summary/page.tsx
+++ b/app/(app)/(configure)/summary/page.tsx
@@ -208,7 +208,10 @@ export default function Summary() {
                   if (error.code === 4001) {
                     // do nothing
                   } else if (error.message.includes('is not a function')) {
-                    // network was still added
+                    /**
+                     * MetaMask v12.14.2 introduced bug with switching networks. Since it succeeds, we still change the text to mark this as successful.
+                     * @see https://github.com/MetaMask/metamask-extension/issues/31464
+                     */
                     setAddedToMetamask(true);
                   } else {
                     alert(`Error ${error.code}: ${error.message}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "allowUnreachableCode": false,
+    "sourceMap": true,
     "noFallthroughCasesInSwitch": true,
     "jsx": "preserve",
     "incremental": true,


### PR DESCRIPTION
Issue: #36. 

As the issue author described, we see a false positive `-32603: h is not a function` error even if _Add to Metamask_ succeeds at adding the protect-website rpc. 

Filtering out the error message is more restrictive than filtering out the code `-32603`, which could be for real internal errors. 

I also added `"sourceMap": true,` to the `tsconfig.json` file so debugging in chrome devtools is possible.