### PR TITLE
Update page to append 'protect-website' to origin id.tsx

### DIFF
--- a/app/(app)/(configure)/summary/page.tsx
+++ b/app/(app)/(configure)/summary/page.tsx
@@ -61,9 +61,11 @@ export default function Summary() {
       rpcUrl.search = urlParams || '';
     }
 
-    if (projectName) {
-      rpcUrl.searchParams.append('originId', 'protect-website');
-    }
+ if (projectName) {
+      rpcUrl.searchParams.append('originId', projectName);
+    }else{
+    rpcUrl.searchParams.append('originId', 'protect-website');
+}
 
     return rpcUrl;
   };

--- a/app/(app)/(configure)/summary/page.tsx
+++ b/app/(app)/(configure)/summary/page.tsx
@@ -62,7 +62,7 @@ export default function Summary() {
     }
 
     if (projectName) {
-      rpcUrl.searchParams.append('originId', projectName);
+      rpcUrl.searchParams.append('originId', 'protect-website');
     }
 
     return rpcUrl;


### PR DESCRIPTION
This pull request includes a small update to the `Summary` function in `page.tsx`. The change ensures that if `projectName` is not defined, a default value of `'protect-website'` is appended to the `originId` search parameter.