### PR TITLE
Metrics appear dynamically on success

### DIFF
--- a/components/RefundMetrics.tsx
+++ b/components/RefundMetrics.tsx
@@ -6,39 +6,39 @@ interface MetricsData {
 }
 
 export async function RefundMetrics() {
-  let mev = 380;
-  let gas = 444;
-
   try {
     const res = await fetch(`${config.refundMetricsApiUrl}/api/metrics`, {
       next: { revalidate: 300 },
     });
-    if (res.ok) {
-      const data: MetricsData = await res.json();
-      mev = Math.round(data.totalMevRefund);
-      gas = Math.round(data.totalGasRefund);
-    }
-  } catch {
-    // Error fetching metrics, use default values
-  }
 
-  return (
-    <a
-      href={config.refundMetricsRedirectUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="bg-white border border-black border-opacity-10 rounded-[60px] inline-flex items-center gap-2 sm:gap-4 h-[35px] sm:h-[41px] px-3 sm:px-[19px] text-black text-opacity-40 hover:text-opacity-60 transition-opacity cursor-pointer"
-    >
-      <span className="text-xs sm:text-[17px] font-medium tracking-[-0.34px] mr-1">
-        Refunds:
-      </span>
-      <span className="text-xs sm:text-[17px] font-medium tracking-[-0.34px]">
-        MEV {mev} ETH
-      </span>
-      <div className="w-[1px] bg-black bg-opacity-30 h-[16px]" />
-      <span className="text-xs sm:text-[17px] font-medium tracking-[-0.34px]">
-        Gas {gas} ETH
-      </span>
-    </a>
-  );
+    if (!res.ok) {
+      return null;
+    }
+
+    const data: MetricsData = await res.json();
+    const mev = Math.round(data.totalMevRefund);
+    const gas = Math.round(data.totalGasRefund);
+
+    return (
+      <a
+        href={config.refundMetricsRedirectUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="bg-white border border-black border-opacity-10 rounded-[60px] inline-flex items-center gap-2 sm:gap-4 h-[35px] sm:h-[41px] px-3 sm:px-[19px] text-black text-opacity-40 hover:text-opacity-60 transition-opacity cursor-pointer"
+      >
+        <span className="text-xs sm:text-[17px] font-medium tracking-[-0.34px] mr-1">
+          Refunds:
+        </span>
+        <span className="text-xs sm:text-[17px] font-medium tracking-[-0.34px]">
+          MEV {mev} ETH
+        </span>
+        <div className="w-[1px] bg-black bg-opacity-30 h-[16px]" />
+        <span className="text-xs sm:text-[17px] font-medium tracking-[-0.34px]">
+          Gas {gas} ETH
+        </span>
+      </a>
+    );
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
This pull request refactors the `RefundMetrics` function in `components/RefundMetrics.tsx` to improve error handling and simplify the code. The key changes ensure that the function returns `null` in case of errors or unsuccessful API responses, rather than relying on default values.

### Error handling improvements:

* Updated the `RefundMetrics` function to return `null` if the API response is not successful, removing the use of default values for `mev` and `gas`. (`[components/RefundMetrics.tsxL9-R21](diffhunk://#diff-d0e85837e55b0602cbca7f1f9a5e2298a89e6b2c43417b86b4c617702817b2a9L9-R21)`)
* Added a `catch` block to return `null` in case of an error during the API call. (`[components/RefundMetrics.tsxR41-R43](diffhunk://#diff-d0e85837e55b0602cbca7f1f9a5e2298a89e6b2c43417b86b4c617702817b2a9R41-R43)`)